### PR TITLE
[VE] Allow copy from vm0 to other mask registers.

### DIFF
--- a/lib/Target/VE/VEInstrInfo.cpp
+++ b/lib/Target/VE/VEInstrInfo.cpp
@@ -426,7 +426,7 @@ void VEInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
     BuildMI(MBB, I, DL, get(VE::LVL), VLReg)
       .addReg(SaveReg, getKillRegState(true));
   }
-  else if (VE::VMRegClass.contains(DestReg, SrcReg))
+  else if (VE::VMCRegClass.contains(SrcReg) && VE::VMRegClass.contains(DestReg))
     BuildMI(MBB, I, DL, get(VE::ANDM), DestReg)
         .addReg(VE::VM0)
         .addReg(SrcReg, getKillRegState(KillSrc));


### PR DESCRIPTION
This fixes crashes with "impossible reg-to-reg copy" when copying from the zero mask register.