### PR TITLE
Fix/vm0 constant reg

### DIFF
--- a/lib/Target/VE/VERegisterInfo.cpp
+++ b/lib/Target/VE/VERegisterInfo.cpp
@@ -186,6 +186,10 @@ BitVector VERegisterInfo::getReservedRegs(const MachineFunction &MF) const {
   Reserved.set(VE::PMC13);
   Reserved.set(VE::PMC14);
 
+  // reserve constant registers
+  Reserved.set(VE::VM0);
+  Reserved.set(VE::VMP0);
+
   // sx18-sx33 are callee-saved registers
   // sx34-sx63 are temporary registers
 

--- a/lib/Target/VE/VERegisterInfo.cpp
+++ b/lib/Target/VE/VERegisterInfo.cpp
@@ -192,6 +192,16 @@ BitVector VERegisterInfo::getReservedRegs(const MachineFunction &MF) const {
   return Reserved;
 }
 
+bool VERegisterInfo::isConstantPhysReg(unsigned PhysReg) const {
+  switch (PhysReg) {
+  case VE::VM0:
+  case VE::VMP0:
+    return true;
+  default:
+    return false;
+  }
+}
+
 const TargetRegisterClass*
 VERegisterInfo::getPointerRegClass(const MachineFunction &MF,
                                       unsigned Kind) const {

--- a/lib/Target/VE/VERegisterInfo.h
+++ b/lib/Target/VE/VERegisterInfo.h
@@ -34,6 +34,7 @@ public:
   const uint32_t *getNoPreservedMask() const override;
 
   BitVector getReservedRegs(const MachineFunction &MF) const override;
+  bool isConstantPhysReg(unsigned PhysReg) const override;
 
   const TargetRegisterClass *getPointerRegClass(const MachineFunction &MF,
                                                 unsigned Kind) const override;

--- a/lib/Target/VE/VERegisterInfo.td
+++ b/lib/Target/VE/VERegisterInfo.td
@@ -180,8 +180,8 @@ def V64 : RegisterClass<"VE",
                          v2i64, v2i32, v2f32, v2f64],
                         64, (sequence "V%u", 0, 63)>;
 // vm0 is reserved for always true
-def VM : RegisterClass<"VE", [v256i1], 64, (sequence "VM%u", 1, 15)>;
-def VM512 : RegisterClass<"VE", [v512i1], 64, (sequence "VMP%u", 1, 7)>;
+def VM : RegisterClass<"VE", [v256i1], 64, (sequence "VM%u", 0, 15)>;
+def VM512 : RegisterClass<"VE", [v512i1], 64, (sequence "VMP%u", 0, 7)>;
 
-def VM_ : RegisterClass<"VE", [v256i1, v4i64], 64, (sequence "VM%u", 1, 15)>;
-def VM512_ : RegisterClass<"VE", [v512i1, v8i64], 64, (sequence "VMP%u", 1, 7)>;
+def VM_ : RegisterClass<"VE", [v256i1, v4i64], 64, (sequence "VM%u", 0, 15)>;
+def VM512_ : RegisterClass<"VE", [v512i1, v8i64], 64, (sequence "VMP%u", 0, 7)>;


### PR DESCRIPTION
This should fix the handling of the special 'vm0/vmp0' registers for good. This is the same strategy for dealing with these registers as used in the AArch64 backend for the 'wzr' register, btw.